### PR TITLE
Add failure notification decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # hermes
-Decorator that emails someone when its function fails.
+
+Hermes provides a decorator that emails a notification when a wrapped function fails.
+
+## Usage
+
+```python
+from hermes import email_on_failure
+
+@email_on_failure("origin@example.com", "dest@example.com")
+def my_task():
+    ...
+```
+
+The email includes the start and failure times, machine name, user, error message and traceback.
+The subject line is "[parent directory] has failed.".
+
+A Markdown template can be supplied to customize the email body:
+
+```python
+@email_on_failure(
+    "origin@example.com", "dest@example.com", markdown="template.md"
+)
+def my_task():
+    ...
+```
+
+The template may reference `{function}`, `{start}`, `{fail_time}`, `{machine}`,
+`{user}`, `{error}`, and `{traceback}`.
+
+The decorator retries once after 60 seconds by default. To control retry
+behavior, supply ``retries`` and ``delay`` in seconds:
+
+```python
+@email_on_failure(
+    "origin@example.com", "dest@example.com", retries=3, delay=30
+)
+def my_task():
+    ...
+```
+
+By default a local SMTP server on `localhost` is used to deliver messages. If an
+Outlook token is supplied via the ``OUTLOOK_TOKEN`` environment variable, the
+Microsoft Outlook API is used instead.
+If a Teams webhook URL is provided via ``TEAMS_WEBHOOK``, the message is also
+posted to Microsoft Teams.
+When the environment variables ``JIRA_URL``, ``JIRA_EMAIL``, ``JIRA_TOKEN`` and
+``JIRA_PROJECT`` are present, a Jira ticket is created with the failure details.
+The issue type defaults to ``Task`` but can be changed with ``JIRA_ISSUE_TYPE``.

--- a/hermes/__init__.py
+++ b/hermes/__init__.py
@@ -1,0 +1,3 @@
+from .notify import email_on_failure
+
+__all__ = ["email_on_failure"]

--- a/hermes/notify.py
+++ b/hermes/notify.py
@@ -1,0 +1,193 @@
+import base64
+import json
+import os
+import smtplib
+import traceback
+import socket
+import getpass
+import inspect
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+import time
+
+
+def email_on_failure(
+    origin: str,
+    destination: str,
+    markdown: Optional[os.PathLike[str] | str] = None,
+    retries: int = 1,
+    delay: float = 60,
+) -> Callable:
+    """Decorator to send an email if the wrapped function raises an exception.
+
+    Parameters
+    ----------
+    origin: str
+        Email address from which the notification will be sent.
+    destination: str
+        Email address to which the notification will be sent.
+    markdown: PathLike or str, optional
+        Path to a Markdown template used to format the email body. The file
+        may reference ``{function}``, ``{start}``, ``{fail_time}``,
+        ``{machine}``, ``{user}``, ``{error}``, and ``{traceback}``.
+    retries: int, optional
+        Number of times to retry ``func`` after an exception. Defaults to one
+        additional attempt.
+    delay: float, optional
+        Seconds to wait between retries. Defaults to 60 seconds.
+    """
+
+    template = Path(markdown).read_text() if markdown else None
+
+    def decorator(func: Callable) -> Callable:
+        def wrapper(*args, **kwargs):
+            start = datetime.now()
+            attempts = 0
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - network call
+                    if attempts >= retries:
+                        fail_time = datetime.now()
+                        machine = socket.gethostname()
+                        user = getpass.getuser()
+                        tb = traceback.format_exc()
+                        file_path = Path(inspect.getfile(func)).resolve()
+                        parent_dir = file_path.parent.name
+                        subject = f"{parent_dir} has failed."
+                        context = {
+                            "function": func.__name__,
+                            "start": start.isoformat(),
+                            "fail_time": fail_time.isoformat(),
+                            "machine": machine,
+                            "user": user,
+                            "error": exc,
+                            "traceback": tb,
+                        }
+                        if template is not None:
+                            body = template.format(**context)
+                        else:
+                            body = (
+                                f"Function {func.__name__} initiated at {start.isoformat()}\n"
+                                f"Failed at {fail_time.isoformat()}\n"
+                                f"Machine: {machine}\n"
+                                f"User: {user}\n"
+                                f"Error: {exc}\n\n"
+                                f"Traceback:\n{tb}"
+                            )
+                        _send_mail(origin, destination, subject, body)
+                        webhook = os.getenv("TEAMS_WEBHOOK")
+                        if webhook:
+                            _send_to_teams(webhook, subject, body)
+                        jira_url = os.getenv("JIRA_URL")
+                        jira_email = os.getenv("JIRA_EMAIL")
+                        jira_token = os.getenv("JIRA_TOKEN")
+                        jira_project = os.getenv("JIRA_PROJECT")
+                        jira_type = os.getenv("JIRA_ISSUE_TYPE", "Task")
+                        if all([jira_url, jira_email, jira_token, jira_project]):
+                            _create_jira_ticket(
+                                jira_url,
+                                jira_email,
+                                jira_token,
+                                jira_project,
+                                jira_type,
+                                subject,
+                                body,
+                            )
+                        raise
+                    attempts += 1
+                    time.sleep(delay)
+
+        return wrapper
+
+    return decorator
+
+
+def _send_mail(origin: str, destination: str, subject: str, body: str) -> None:
+    """Send ``body`` with ``subject`` from ``origin`` to ``destination``.
+
+    If the environment variable ``OUTLOOK_TOKEN`` is set, the message is sent
+    using the Microsoft Outlook API. Otherwise, a local SMTP server on
+    ``localhost`` is used.
+    """
+
+    token = os.getenv("OUTLOOK_TOKEN")
+    if token:
+        _send_via_outlook(origin, destination, subject, body, token)
+    else:
+        _send_via_smtp(origin, destination, subject, body)
+
+
+def _send_via_smtp(origin: str, destination: str, subject: str, body: str) -> None:
+    message = f"Subject: {subject}\n\n{body}"
+    with smtplib.SMTP("localhost") as smtp:  # pragma: no cover - network call
+        smtp.sendmail(origin, destination, message)
+
+
+def _send_via_outlook(
+    origin: str, destination: str, subject: str, body: str, token: str
+) -> None:
+    payload = json.dumps(
+        {
+            "message": {
+                "subject": subject,
+                "body": {"contentType": "Text", "content": body},
+                "from": {"emailAddress": {"address": origin}},
+                "toRecipients": [
+                    {"emailAddress": {"address": destination}}
+                ],
+            },
+            "saveToSentItems": "false",
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        "https://graph.microsoft.com/v1.0/me/sendMail",
+        data=payload,
+        method="POST",
+    )
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+
+    with urllib.request.urlopen(req):  # pragma: no cover - network call
+        pass
+
+
+def _send_to_teams(webhook: str, subject: str, body: str) -> None:
+    payload = json.dumps({"text": f"**{subject}**\n\n{body}"}).encode("utf-8")
+    req = urllib.request.Request(webhook, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req):  # pragma: no cover - network call
+        pass
+
+
+def _create_jira_ticket(
+    url: str,
+    email: str,
+    token: str,
+    project: str,
+    issue_type: str,
+    summary: str,
+    description: str,
+) -> None:
+    payload = json.dumps(
+        {
+            "fields": {
+                "summary": summary,
+                "description": description,
+                "project": {"key": project},
+                "issuetype": {"name": issue_type},
+            }
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{url.rstrip('/')}/rest/api/3/issue", data=payload, method="POST"
+    )
+    auth = base64.b64encode(f"{email}:{token}".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req):  # pragma: no cover - network call
+        pass

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+import os
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure package root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hermes import email_on_failure
+
+
+def test_email_sent_on_failure():
+    @email_on_failure("from@example.com", "to@example.com")
+    def explode():
+        raise RuntimeError("boom")
+
+    with patch("hermes.notify.smtplib.SMTP") as smtp, patch(
+        "hermes.notify.time.sleep"
+    ):
+        with pytest.raises(RuntimeError):
+            explode()
+        smtp.assert_called_with("localhost")
+        smtp.return_value.__enter__.return_value.sendmail.assert_called_once()
+
+
+def test_outlook_api_used_when_token_present():
+    @email_on_failure("from@example.com", "to@example.com")
+    def explode():
+        raise RuntimeError("boom")
+
+    with patch.dict(os.environ, {"OUTLOOK_TOKEN": "token"}, clear=True):
+        with patch("hermes.notify.urllib.request.urlopen") as urlopen, patch(
+            "hermes.notify.smtplib.SMTP"
+        ) as smtp, patch("hermes.notify.time.sleep"):
+            urlopen.return_value.__enter__.return_value.read.return_value = b""
+            with pytest.raises(RuntimeError):
+                explode()
+            urlopen.assert_called_once()
+            smtp.assert_not_called()
+
+
+def test_markdown_template_used(tmp_path):
+    template = tmp_path / "body.md"
+    template.write_text("Start: {start}\nError: {error}\n")
+
+    @email_on_failure(
+        "from@example.com", "to@example.com", markdown=template
+    )
+    def explode():
+        raise RuntimeError("boom")
+
+    with patch("hermes.notify._send_mail") as send_mail, patch(
+        "hermes.notify.time.sleep"
+    ):
+        with pytest.raises(RuntimeError):
+            explode()
+        body = send_mail.call_args[0][3]
+        assert "Start:" in body
+        assert "Error: boom" in body
+
+
+def test_teams_notification_when_webhook_present():
+    @email_on_failure("from@example.com", "to@example.com")
+    def explode():
+        raise RuntimeError("boom")
+
+    with patch.dict(
+        os.environ, {"TEAMS_WEBHOOK": "https://example.com/webhook"}, clear=True
+    ):
+        with patch("hermes.notify.urllib.request.urlopen") as urlopen, patch(
+            "hermes.notify.smtplib.SMTP"
+        ) as smtp, patch("hermes.notify.time.sleep"):
+            urlopen.return_value.__enter__.return_value.read.return_value = b""
+            with pytest.raises(RuntimeError):
+                explode()
+            urlopen.assert_called_once()
+            smtp.assert_called_with("localhost")
+
+
+def test_jira_ticket_when_configured():
+    @email_on_failure("from@example.com", "to@example.com")
+    def explode():
+        raise RuntimeError("boom")
+
+    env = {
+        "JIRA_URL": "https://example.atlassian.net",
+        "JIRA_EMAIL": "user@example.com",
+        "JIRA_TOKEN": "token",
+        "JIRA_PROJECT": "PROJ",
+    }
+
+    with patch.dict(os.environ, env, clear=True):
+        with patch("hermes.notify.urllib.request.urlopen") as urlopen, patch(
+            "hermes.notify.smtplib.SMTP"
+        ) as smtp, patch("hermes.notify.time.sleep"):
+            urlopen.return_value.__enter__.return_value.read.return_value = b""
+            with pytest.raises(RuntimeError):
+                explode()
+            urlopen.assert_called_once()
+            smtp.assert_called_with("localhost")
+
+
+def test_retry_succeeds_without_email():
+    calls = {"count": 0}
+
+    @email_on_failure("from@example.com", "to@example.com", retries=1, delay=1)
+    def sometimes():
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise RuntimeError("boom")
+        return "ok"
+
+    with patch("hermes.notify._send_mail") as send_mail, patch(
+        "hermes.notify.time.sleep"
+    ) as sleep:
+        assert sometimes() == "ok"
+        assert calls["count"] == 2
+        send_mail.assert_not_called()
+        sleep.assert_called_once_with(1)
+
+
+def test_retry_exhausted_sends_email():
+    @email_on_failure("from@example.com", "to@example.com", retries=2, delay=5)
+    def explode():
+        raise RuntimeError("boom")
+
+    with patch("hermes.notify._send_mail") as send_mail, patch(
+        "hermes.notify.time.sleep"
+    ) as sleep:
+        with pytest.raises(RuntimeError):
+            explode()
+        assert sleep.call_count == 2
+        send_mail.assert_called_once()


### PR DESCRIPTION
## Summary
- add `email_on_failure` decorator that emails when wrapped function raises an exception
- support Microsoft Outlook API when `OUTLOOK_TOKEN` is set
- post to Microsoft Teams when `TEAMS_WEBHOOK` is provided
- create Jira ticket when `JIRA_URL`, `JIRA_EMAIL`, `JIRA_TOKEN` and `JIRA_PROJECT` are set
- allow providing a Markdown template to customize email body
- allow automatic retries with configurable count and delay before sending notification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1085ef6848329abfc6b5b07e53a40